### PR TITLE
Run test cases concurrently with `pytest-asyncio-cooperative`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+import pytest
+
+import asyncio
+import multiprocessing
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+class _NSemaphore:
+    def __init__(self, value=1):
+        assert value >= 0
+        self._value = value
+        self._cond = asyncio.Condition()
+
+    async def acquire(self, n=1):
+        assert n >= 1
+        async with self._cond:
+            await self._cond.wait_for(lambda: self._value >= n)
+            self._value -= n
+
+    async def release(self, n=1):
+        assert n >= 1
+        async with self._cond:
+            self._value += n
+            self._cond.notify(n)
+
+    @asynccontextmanager
+    async def __call__(self, n=1):
+        await self.acquire(n)
+        try:
+            yield
+        finally:
+            await self.release(n)
+
+
+@pytest.fixture(scope="session")
+def max_cpus():
+    return multiprocessing.cpu_count()
+
+@pytest.fixture(scope="session")
+def reserve_cpus(max_cpus):
+    return _NSemaphore(max_cpus)
+
+@pytest.fixture(scope="session")
+def run_case(reserve_cpus, max_cpus):
+    async def _run_case(case, *, cpus=1):
+        case = Path(case)
+        assert cpus >= 1
+        cpus = min(cpus, max_cpus) # Oversubscribe if necessary
+
+        clean = await asyncio.create_subprocess_exec("./clean", cwd=case, stdout=asyncio.subprocess.DEVNULL)
+        await clean.wait()
+
+        async with reserve_cpus(cpus):
+            run = await asyncio.create_subprocess_exec("./run", cwd=case, stdout=asyncio.subprocess.DEVNULL)
+            await run.wait()
+
+        assert run.returncode == 0, f"Case {case.name}: run failed"
+
+        return case
+    return _run_case

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --asyncio-task-timeout 600

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-pytest>=7.1.1,<8
-numpy>=1.21.6,<2
+pytest==7.*
+pytest-asyncio-cooperative>=0.30.0,<0.31
+numpy==1.*
 PyFoam>=2021.6,<=2023.7

--- a/tests/test_dispersion/test_dispersion.py
+++ b/tests/test_dispersion/test_dispersion.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 import math
 from pathlib import Path
 
@@ -9,13 +8,12 @@ import numpy as np
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module")
-def dispersion_case():
-    subprocess.run(["./clean"], cwd=DIR)
-    subprocess.run(["./run"], cwd=DIR, check=True)
-    return DIR
+async def dispersion_case(run_case):
+    return await run_case(DIR)
 
 
-def test_dispersion(dispersion_case):
+@pytest.mark.asyncio_cooperative
+async def test_dispersion(dispersion_case):
     alphaT=5e-5
 
     with open(dispersion_case / '50/ampholyte.TARTRAZINE','r') as f:

--- a/tests/test_exhaustible/test_exhaustible.py
+++ b/tests/test_exhaustible/test_exhaustible.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -10,14 +9,13 @@ from PyFoam.RunDictionary.ParsedParameterFile import ParsedParameterFile
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module")
-def exhaustible_case():
-    subprocess.run(["./clean"], cwd=DIR)
-    subprocess.run(["./run"], cwd=DIR, check=True)
-    return DIR
+async def exhaustible_case(run_case):
+    return await run_case(DIR)
 
 
-def test_infiltration(exhaustible_case):
-    theta0 = np.array(ParsedParameterFile(exhaustible_case / "0" / "theta")["internalField"].value())
+@pytest.mark.asyncio_cooperative
+async def test_infiltration(exhaustible_case):
+    theta0 = np.array(ParsedParameterFile(DIR / "0" / "theta")["internalField"].value())
     dV = 30e-3*10e-3*0.18e-3/5000
     amount = 2e-8
 

--- a/tests/test_reaction/test_reaction.py
+++ b/tests/test_reaction/test_reaction.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -9,13 +8,12 @@ from PyFoam.RunDictionary.ParsedParameterFile import ParsedParameterFile
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module")
-def reaction_case():
-    subprocess.run(["./clean"], cwd=DIR)
-    subprocess.run(["./run"], cwd=DIR, check=True)
-    return DIR
+async def reaction_case(run_case):
+    return await run_case(DIR)
 
 
-def test_reaction(reaction_case):
+@pytest.mark.asyncio_cooperative
+async def test_reaction(reaction_case):
     a0 = np.array(ParsedParameterFile(reaction_case / "0" / "A")["internalField"].value())
     b0 = np.array(ParsedParameterFile(reaction_case / "0" / "B")["internalField"].value())
     c0 = np.array(ParsedParameterFile(reaction_case / "0" / "C")["internalField"].value())

--- a/tests/test_retardation/test_retardation.py
+++ b/tests/test_retardation/test_retardation.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -10,13 +9,12 @@ from PyFoam.RunDictionary.ParsedParameterFile import ParsedParameterFile
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module")
-def retardation_case():
-    subprocess.run(["./clean"], cwd=DIR)
-    subprocess.run(["./run"], cwd=DIR, check=True)
-    return DIR
+async def retardation_case(run_case):
+    return await run_case(DIR)
 
 
-def test_retardation(retardation_case):
+@pytest.mark.asyncio_cooperative
+async def test_retardation(retardation_case):
     a5 =  np.array(ParsedParameterFile(retardation_case / "5" / "A")["internalField"].value())
     b10 =  np.array(ParsedParameterFile(retardation_case / "10" / "B")["internalField"].value())
     

--- a/tests/test_validity/test_validity.py
+++ b/tests/test_validity/test_validity.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -10,14 +9,12 @@ from PyFoam.RunDictionary.ParsedParameterFile import ParsedParameterFile
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module", params=["LETxs", "LETd"])
-def validity_case(request):
-    case = DIR / request.param
-    subprocess.run(["./clean"], cwd=case)
-    subprocess.run(["./run"], cwd=case, check=True)
-    return case
+async def validity_case(run_case, request):
+    return await run_case(DIR / request.param)
 
 
-def test_validity(validity_case):
+@pytest.mark.asyncio_cooperative
+async def test_validity(validity_case):
     actual = np.array(ParsedParameterFile(validity_case / "100" / "theta")["internalField"].value())
     expected = np.array(ParsedParameterFile(validity_case / "100" / "theta.expected")["internalField"].value())
 

--- a/tests/test_velocity/test_velocity.py
+++ b/tests/test_velocity/test_velocity.py
@@ -1,6 +1,5 @@
 import pytest
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -10,13 +9,12 @@ from PyFoam.RunDictionary.ParsedParameterFile import ParsedParameterFile
 DIR = Path(__file__).parent
 
 @pytest.fixture(scope="module")
-def velocity_case():
-    subprocess.run(["./clean"],cwd=DIR)
-    subprocess.run(["./run"], cwd=DIR, check=True)
-    return DIR
+async def velocity_case(run_case):
+    return await run_case(DIR)
 
 
-def test_infiltration(velocity_case):
+@pytest.mark.asyncio_cooperative
+async def test_infiltration(velocity_case):
     theta0 = np.array(ParsedParameterFile(velocity_case / "0" / "theta")["internalField"].value())
     U = np.array(ParsedParameterFile(velocity_case / "0" / "U")["boundaryField"]["left"]["value"].value())[0]
     h = 30e-3/5000


### PR DESCRIPTION
Run many test cases at the same time (depending on available # of CPUs) via [`pytest-asyncio-cooperative`](https://github.com/willemt/pytest-asyncio-cooperative). Cuts the time required to run the full test suite by half on an 8-core machine.

This should be ready as it is now, but these open PRs at `pytest-asyncio-cooperative` will be helpful: https://github.com/willemt/pytest-asyncio-cooperative/pull/37, https://github.com/willemt/pytest-asyncio-cooperative/pull/38, https://github.com/willemt/pytest-asyncio-cooperative/pull/39 
